### PR TITLE
refactor(sidechain): refactor sidechain deployment scripts

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -4,28 +4,14 @@ import "@typechain/hardhat";
 import "hardhat-gas-reporter";
 import "solidity-coverage";
 import "@nomiclabs/hardhat-etherscan";
-import "./tasks/coverage";
 import "solidity-docgen";
-
 import { resolve } from "path";
-
 import { config as dotenvConfig } from "dotenv";
 import { HardhatUserConfig } from "hardhat/config";
+import "./tasks/coverage";
+import { chainIds } from "./tasks/utils/networkAddressFactory";
 
 dotenvConfig({ path: resolve(__dirname, "./.env") });
-
-export const chainIds = {
-    goerli: 5,
-    hardhat: 31337,
-    kovan: 42,
-    mainnet: 1,
-    rinkeby: 4,
-    ropsten: 3,
-    arbitrum: 42161,
-    arbitrumGoerli: 421613,
-    polygon: 137,
-    gnosis: 100,
-};
 
 const compilerSettings = {
     metadata: {

--- a/scripts/deployBridgeDelegates.ts
+++ b/scripts/deployBridgeDelegates.ts
@@ -14,7 +14,7 @@ import { deployContract } from "../tasks/utils";
 import { ExtSystemConfig } from "./deploySystem";
 import { CanonicalPhaseDeployed } from "./deploySidechain";
 
-interface SimplyBridgeDelegateDeployed {
+export interface SimplyBridgeDelegateDeployed {
     bridgeDelegateSender: BridgeDelegateSender;
     bridgeDelegateReceiver: BridgeDelegateReceiver;
 }

--- a/scripts/deployMocks.ts
+++ b/scripts/deployMocks.ts
@@ -21,6 +21,8 @@ import {
     MockBalancerPoolToken__factory,
     MockBalancerVault,
     MockBalancerVault__factory,
+    LZEndpointMock__factory,
+    LZEndpointMock,
 } from "../types/generated";
 import { deployContract } from "../tasks/utils";
 import { MultisigConfig, DistroList, ExtSystemConfig, NamingConfig } from "./deploySystem";
@@ -39,10 +41,10 @@ interface DeployMocksResult {
     balancerVault: MockBalancerVault;
     bal: MockERC20;
     weth: MockERC20;
+    lzEndpoint: LZEndpointMock;
     addresses: ExtSystemConfig;
     namingConfig: NamingConfig;
 }
-
 /** @dev Recreates the Convex distribution list */
 function getMockDistro(): DistroList {
     return {
@@ -113,7 +115,12 @@ async function getMockMultisigs(
     };
 }
 
-async function deployMocks(hre: HardhatRuntimeEnvironment, signer: Signer, debug = false): Promise<DeployMocksResult> {
+async function deployMocks(
+    hre: HardhatRuntimeEnvironment,
+    signer: Signer,
+    debug = false,
+    chainId = 111,
+): Promise<DeployMocksResult> {
     const deployer = signer;
     const deployerAddress = await deployer.getAddress();
 
@@ -260,6 +267,17 @@ async function deployMocks(hre: HardhatRuntimeEnvironment, signer: Signer, debug
         debug,
     );
 
+    // -----------------------------
+    // 2 Sidechain
+    // -----------------------------
+    const lzEndpoint = await deployContract<LZEndpointMock>(
+        hre,
+        new LZEndpointMock__factory(deployer),
+        "lzEndpoint",
+        [chainId],
+        {},
+        debug,
+    );
     return {
         lptoken,
         crv,
@@ -273,6 +291,7 @@ async function deployMocks(hre: HardhatRuntimeEnvironment, signer: Signer, debug
         balancerVault,
         bal,
         weth,
+        lzEndpoint,
         addresses: {
             token: crv.address,
             tokenBpt: crvBpt.address,
@@ -305,6 +324,7 @@ async function deployMocks(hre: HardhatRuntimeEnvironment, signer: Signer, debug
                 poolIds: [ZERO_KEY],
                 assetsIn: [feeToken.address],
             },
+            lzEndpoint: lzEndpoint.address,
         },
         namingConfig: {
             cvxName: "Convex Finance",

--- a/scripts/deploySidechain.ts
+++ b/scripts/deploySidechain.ts
@@ -493,15 +493,6 @@ export async function setTrustedRemoteCanonical(
         ),
     );
     await waitForTx(tx, debug, waitForBlocks);
-
-    tx = await canonical.auraBalProxyOFT.setTrustedRemote(
-        sidechainLzChainId,
-        ethers.utils.solidityPack(
-            ["address", "address"],
-            [sidechain.auraBalOFT.address, canonical.auraBalProxyOFT.address],
-        ),
-    );
-    await waitForTx(tx, debug, waitForBlocks);
 }
 
 export async function setTrustedRemoteSidechain(

--- a/scripts/deploySidechain.ts
+++ b/scripts/deploySidechain.ts
@@ -8,8 +8,8 @@ import {
     AuraProxyOFT__factory,
     BoosterLite,
     BoosterLite__factory,
-    BoosterOwner,
-    BoosterOwner__factory,
+    BoosterOwnerLite,
+    BoosterOwnerLite__factory,
     L2Coordinator,
     L2Coordinator__factory,
     L1Coordinator,
@@ -18,14 +18,6 @@ import {
     Create2Factory__factory,
     ExtraRewardStashV3,
     ExtraRewardStashV3__factory,
-    MockBalancerPoolToken,
-    MockBalancerPoolToken__factory,
-    MockCurveGauge,
-    MockCurveGauge__factory,
-    MockCurveMinter,
-    MockCurveMinter__factory,
-    MockERC20,
-    MockERC20__factory,
     PoolManagerLite,
     PoolManagerLite__factory,
     ProxyFactory,
@@ -49,11 +41,10 @@ import {
     SimpleStrategy__factory,
     SimpleStrategy,
 } from "../types";
-import { ExtSystemConfig, Phase2Deployed, Phase6Deployed } from "./deploySystem";
-import { simpleToExactAmount } from "../test-utils/math";
+import { ExtSystemConfig, MultisigConfig, Phase2Deployed, Phase6Deployed } from "./deploySystem";
 import { ZERO_ADDRESS } from "../test-utils/constants";
 import { deployContract, deployContractWithCreate2, waitForTx } from "../tasks/utils";
-import { ExtSidechainConfig, SidechainAddresses, SidechainNaming } from "../tasks/deploy/sidechain-types";
+import { ExtSidechainConfig, SidechainNaming, SidechainMultisigConfig } from "../types/sidechain-types";
 import { AuraBalVaultDeployed } from "tasks/deploy/mainnet-config";
 
 export interface CanonicalPhaseDeployed {
@@ -64,19 +55,36 @@ export interface CanonicalPhaseDeployed {
 
 export async function deployCanonicalPhase(
     hre: HardhatRuntimeEnvironment,
+    deployer: Signer,
+    multisigs: MultisigConfig,
     config: ExtSystemConfig,
     phase2: Phase2Deployed,
     phase6: Phase6Deployed,
     auraBalVault: AuraBalVaultDeployed,
-    deployer: Signer,
     debug: boolean = false,
     waitForBlocks: number = 0,
 ): Promise<CanonicalPhaseDeployed> {
+    // -----------------------------
+    // Post:
+    //     Protocol DAO : l1Booster.setBridgeDelegate(l1Coordinator.address);
+    //     Protocol DAO : l1Coordinator.setBridgeDelegate(sidechainLzChainId, bridgeDelegateReceiver.address);
+    //     Protocol DAO : l1Coordinator.setL2Coordinator(sidechainLzChainId, sidechain.l2Coordinator.address);
+    // -----------------------------
+
     const auraProxyOFT = await deployContract<AuraProxyOFT>(
         hre,
         new AuraProxyOFT__factory(deployer),
         "AuraProxyOFT",
         [config.lzEndpoint, phase2.cvx.address, phase2.cvxLocker.address],
+        {},
+        debug,
+        waitForBlocks,
+    );
+    const auraBalProxyOFT = await deployContract<AuraBalProxyOFT>(
+        hre,
+        new AuraBalProxyOFT__factory(deployer),
+        "AuraBalProxyOFT",
+        [config.lzEndpoint, phase2.cvxCrv.address, auraBalVault.vault.address],
         {},
         debug,
         waitForBlocks,
@@ -92,15 +100,14 @@ export async function deployCanonicalPhase(
         waitForBlocks,
     );
 
-    const auraBalProxyOFT = await deployContract<AuraBalProxyOFT>(
-        hre,
-        new AuraBalProxyOFT__factory(deployer),
-        "AuraBalProxyOFT",
-        [config.lzEndpoint, phase2.cvxCrv.address, auraBalVault.vault.address],
-        {},
-        debug,
-        waitForBlocks,
-    );
+    let tx = await l1Coordinator.transferOwnership(multisigs.daoMultisig);
+    await waitForTx(tx, debug, waitForBlocks);
+
+    tx = await auraProxyOFT.transferOwnership(multisigs.daoMultisig);
+    await waitForTx(tx, debug, waitForBlocks);
+
+    tx = await auraBalProxyOFT.transferOwnership(multisigs.daoMultisig);
+    await waitForTx(tx, debug, waitForBlocks);
 
     return { auraProxyOFT, auraBalProxyOFT, l1Coordinator };
 }
@@ -115,7 +122,7 @@ interface Factories {
 export interface SidechainDeployed {
     voterProxy: VoterProxyLite;
     booster: BoosterLite;
-    boosterOwner: BoosterOwner;
+    boosterOwner: BoosterOwnerLite;
     factories: Factories;
     poolManager: PoolManagerLite;
     l2Coordinator: L2Coordinator;
@@ -134,7 +141,6 @@ export interface SidechainDeployed {
  *      - TokenFactory
  *      - ProxyFactory
  *      - PoolManagerLite
- *      - BoosterOwner
  *
  *  - Deploys with the different address the following contracts.
  *      - AuraOFT
@@ -142,26 +148,52 @@ export interface SidechainDeployed {
  *      - RewardFactory
  *      - StashFactoryV2
  *      - ExtraRewardStashV3
- *      - BoosterOwner
+ *      - BoosterOwnerLite
  *
  * @param {HardhatRuntimeEnvironment} hre - The Hardhat runtime environment
- * @param {SidechainNaming} naming - Naming configuration.
- * @param {SidechainAddresses} addresses - List of Sidechain addresses
- * @param {ExtSidechainConfig} extConfig - The external Sidechain configuration
  * @param {Signer} deployer - The deployer signer
+ * @param {SidechainNaming} naming - Naming configuration.
+ * @param {SidechainMultisigConfig} multisigs - List of Sidechain multisigs addresses
+ * @param {ExtSidechainConfig} extConfig - The external Sidechain configuration
  * @param {boolean} debug - Weather console log or not the details of the tx
  * @param {number} waitForBlocks - Number of blocks to wait after the deployment of each contract.
  */
 export async function deploySidechainSystem(
     hre: HardhatRuntimeEnvironment,
-    naming: SidechainNaming,
-    addresses: SidechainAddresses,
-    extConfig: ExtSidechainConfig,
     deployer: Signer,
+    naming: SidechainNaming,
+    multisigs: SidechainMultisigConfig,
+    extConfig: ExtSidechainConfig,
     debug: boolean = false,
     waitForBlocks: number = 0,
 ): Promise<SidechainDeployed> {
     const deployerAddress = await deployer.getAddress();
+
+    // -----------------------------
+    // Pre-1:  Deploy create2Factory
+    //         Protocol DAO : create2Factory.updateDeployer(deployer.address, true);
+    //         Protocol DAO : booster.bridgeDelegate(l1Coordinator.address)
+    // -----------------------------
+    // 1. Sidechain system:
+    //     - voterProxy
+    //     - cvx (coordinator)
+    //     - boosterLite
+    //     - factories (reward, token, proxy, stash)
+    //     - pool management (poolManager + boosterOwner)
+    // -----------------------------
+    // -----------------------------
+    // Post-1: L1 add trusted remotes to layerzero endpoints
+    //         @see setTrustedRemoteCanonical()
+    //         Protocol DAO : 1Coordinator.setTrustedRemote(L2_CHAIN_ID, [l2Coordinator.address, l1Coordinator.address]);
+    //         Protocol DAO : auraProxyOFT.setTrustedRemote(L2_CHAIN_ID, [auraOFT.address, auraProxyOFT.address]);
+    //         Protocol DAO : auraProxyOFT.setTrustedRemote(L2_CHAIN_ID, [auraBalOFT.address, auraBalProxyOFT.address]);
+    // Post-1: L2 add trusted remotes to layerzero endpoints
+    //         @see setTrustedRemoteSidechain()
+    //         Protocol DAO : l2Coordinator.setTrustedRemote(L1_CHAIN_ID, [l1Coordinator.address, l2Coordinator.address]);
+    //         Protocol DAO : auraOFT.setTrustedRemote(L1_CHAIN_ID, [auraProxyOFT.address, auraOFT.address]);
+    //         Protocol DAO : auraBalOFT.setTrustedRemote(L1_CHAIN_ID, [auraBalProxyOFT.address, auraBalOFT.address]);
+    // -----------------------------
+
     const create2Options = { amount: 0, salt: "1", callbacks: [] };
     const deployOptions = {
         overrides: {},
@@ -177,13 +209,12 @@ export async function deploySidechainSystem(
         },
     });
 
-    const create2Factory = Create2Factory__factory.connect(addresses.create2Factory, deployer);
+    const create2Factory = Create2Factory__factory.connect(extConfig.create2Factory, deployer);
     const voterProxyInitialize = VoterProxyLite__factory.createInterface().encodeFunctionData("initialize", [
-        addresses.minter,
-        addresses.token,
+        extConfig.minter,
+        extConfig.token,
         deployerAddress,
     ]);
-
     const voterProxy = await deployContractWithCreate2<VoterProxyLite, VoterProxyLite__factory>(
         hre,
         create2Factory,
@@ -193,7 +224,7 @@ export async function deploySidechainSystem(
         deployOptionsWithCallbacks([voterProxyInitialize]),
     );
 
-    const auraOFTTransferOwnership = L2Coordinator__factory.createInterface().encodeFunctionData("transferOwnership", [
+    const auraOFTTransferOwnership = AuraOFT__factory.createInterface().encodeFunctionData("transferOwnership", [
         deployerAddress,
     ]);
     const auraOFT = await deployContractWithCreate2<AuraOFT, AuraOFT__factory>(
@@ -201,11 +232,11 @@ export async function deploySidechainSystem(
         create2Factory,
         new AuraOFT__factory(deployer),
         "AuraOFT",
-        [naming.auraOftName, naming.auraOftSymbol, addresses.lzEndpoint, extConfig.canonicalChainId],
+        [naming.auraOftName, naming.auraOftSymbol, extConfig.lzEndpoint, extConfig.canonicalChainId],
         deployOptionsWithCallbacks([auraOFTTransferOwnership]),
     );
 
-    const coordinatorTransferOwnership = L2Coordinator__factory.createInterface().encodeFunctionData(
+    const l2CoordinatorTransferOwnership = L2Coordinator__factory.createInterface().encodeFunctionData(
         "transferOwnership",
         [deployerAddress],
     );
@@ -214,15 +245,15 @@ export async function deploySidechainSystem(
         hre,
         create2Factory,
         new L2Coordinator__factory(deployer),
-        "Coordinator",
-        [addresses.lzEndpoint, auraOFT.address, extConfig.canonicalChainId],
-        deployOptionsWithCallbacks([coordinatorTransferOwnership]),
+        "L2Coordinator",
+        [extConfig.lzEndpoint, auraOFT.address, extConfig.canonicalChainId],
+        deployOptionsWithCallbacks([l2CoordinatorTransferOwnership]),
     );
     const cvxTokenAddress = l2Coordinator.address;
 
     const boosterLiteInitialize = BoosterLite__factory.createInterface().encodeFunctionData("initialize", [
         cvxTokenAddress,
-        addresses.token,
+        extConfig.token,
         deployerAddress,
     ]);
     const booster = await deployContractWithCreate2<BoosterLite, BoosterLite__factory>(
@@ -239,7 +270,7 @@ export async function deploySidechainSystem(
         create2Factory,
         new RewardFactory__factory(deployer),
         "RewardFactory",
-        [booster.address, addresses.token],
+        [booster.address, extConfig.token],
         deployOptions,
     );
     const tokenFactory = await deployContractWithCreate2<TokenFactory, TokenFactory__factory>(
@@ -273,12 +304,12 @@ export async function deploySidechainSystem(
         create2Factory,
         new ExtraRewardStashV3__factory(deployer),
         "ExtraRewardStashV3",
-        [addresses.token],
+        [extConfig.token],
         deployOptions,
     );
 
     const poolManagerSetOperator = PoolManagerLite__factory.createInterface().encodeFunctionData("setOperator", [
-        addresses.daoMultisig,
+        multisigs.daoMultisig,
     ]);
     const poolManager = await deployContractWithCreate2<PoolManagerLite, PoolManagerLite__factory>(
         hre,
@@ -289,12 +320,12 @@ export async function deploySidechainSystem(
         deployOptionsWithCallbacks([poolManagerSetOperator]),
     );
     // Not a constant address
-    const boosterOwner = await deployContractWithCreate2<BoosterOwner, BoosterOwner__factory>(
+    const boosterOwner = await deployContractWithCreate2<BoosterOwnerLite, BoosterOwnerLite__factory>(
         hre,
         create2Factory,
-        new BoosterOwner__factory(deployer),
-        "BoosterOwner",
-        [addresses.daoMultisig, poolManager.address, booster.address, stashFactory.address, ZERO_ADDRESS, true],
+        new BoosterOwnerLite__factory(deployer),
+        "BoosterOwnerLite",
+        [multisigs.daoMultisig, poolManager.address, booster.address, stashFactory.address, ZERO_ADDRESS, true],
         deployOptions,
     );
 
@@ -306,7 +337,7 @@ export async function deploySidechainSystem(
         create2Factory,
         new AuraBalOFT__factory(deployer),
         "AuraBalOFT",
-        [naming.auraBalOftName, naming.auraBalOftSymbol, addresses.lzEndpoint],
+        [naming.auraBalOftName, naming.auraBalOftSymbol, extConfig.lzEndpoint],
         deployOptionsWithCallbacks([auraBalOFTTransferOwnership]),
     );
 
@@ -316,7 +347,7 @@ export async function deploySidechainSystem(
         new VirtualRewardFactory__factory(deployer),
         "VirtualRewardFactory",
         [],
-        {},
+        deployOptions,
     );
 
     const auraBalVaultTransferOwnership = AuraBalVault__factory.createInterface().encodeFunctionData(
@@ -338,7 +369,7 @@ export async function deploySidechainSystem(
         new SimpleStrategy__factory(deployer),
         "SimpleStrategy",
         [auraBalOFT.address, auraBalVault.address],
-        {},
+        deployOptions,
     );
 
     let tx: ContractTransaction;
@@ -349,7 +380,16 @@ export async function deploySidechainSystem(
     tx = await auraBalVault.addExtraReward(auraOFT.address);
     await waitForTx(tx, debug, waitForBlocks);
 
-    tx = await l2Coordinator.initialize(booster.address, addresses.token);
+    tx = await l2Coordinator.initialize(booster.address, extConfig.token);
+    await waitForTx(tx, debug, waitForBlocks);
+
+    tx = await l2Coordinator.transferOwnership(multisigs.daoMultisig);
+    await waitForTx(tx, debug, waitForBlocks);
+
+    tx = await auraOFT.transferOwnership(multisigs.daoMultisig);
+    await waitForTx(tx, debug, waitForBlocks);
+
+    tx = await auraBalOFT.transferOwnership(multisigs.daoMultisig);
     await waitForTx(tx, debug, waitForBlocks);
 
     tx = await voterProxy.setOperator(booster.address);
@@ -358,7 +398,7 @@ export async function deploySidechainSystem(
     tx = await stashFactory.setImplementation(ZERO_ADDRESS, ZERO_ADDRESS, stashV3.address);
     await waitForTx(tx, debug, waitForBlocks);
 
-    tx = await voterProxy.setOwner(addresses.daoMultisig);
+    tx = await voterProxy.setOwner(multisigs.daoMultisig);
     await waitForTx(tx, debug, waitForBlocks);
 
     tx = await booster.setRewardContracts(l2Coordinator.address);
@@ -376,7 +416,7 @@ export async function deploySidechainSystem(
     tx = await booster.setFees(550, 1100, 50, 0);
     await waitForTx(tx, debug, waitForBlocks);
 
-    tx = await booster.setFeeManager(addresses.daoMultisig);
+    tx = await booster.setFeeManager(multisigs.daoMultisig);
     await waitForTx(tx, debug, waitForBlocks);
 
     tx = await booster.setOwner(boosterOwner.address);
@@ -400,68 +440,6 @@ export async function deploySidechainSystem(
         auraBalVault,
         auraBalStrategy,
     };
-}
-
-export interface SidechainMocksDeployed {
-    token: MockERC20;
-    bpt: MockBalancerPoolToken;
-    minter: MockCurveMinter;
-    gauge: MockCurveGauge;
-}
-
-export async function deploySidechainMocks(
-    hre: HardhatRuntimeEnvironment,
-    deployer: Signer,
-    debug: boolean,
-    waitForBlocks: number,
-): Promise<SidechainMocksDeployed> {
-    const deployerAddress = await deployer.getAddress();
-
-    const token = await deployContract<MockERC20>(
-        hre,
-        new MockERC20__factory(deployer),
-        "MockERC20",
-        ["mockToken", "mockToken", 18, deployerAddress, 10000000],
-        {},
-        debug,
-        waitForBlocks,
-    );
-
-    const bpt = await deployContract<MockBalancerPoolToken>(
-        hre,
-        new MockBalancerPoolToken__factory(deployer),
-        "MockBalancerPoolToken",
-        [18, deployerAddress, 100],
-        {},
-        debug,
-        waitForBlocks,
-    );
-
-    const minter = await deployContract<MockCurveMinter>(
-        hre,
-        new MockCurveMinter__factory(deployer),
-        "MockCurveMinter",
-        [token.address, simpleToExactAmount(10)],
-        {},
-        debug,
-        waitForBlocks,
-    );
-
-    const gauge = await deployContract<MockCurveGauge>(
-        hre,
-        new MockCurveGauge__factory(deployer),
-        "MockCurveGauge",
-        ["MockGauge", "MOCK", bpt.address, []],
-        {},
-        debug,
-        waitForBlocks,
-    );
-
-    const amount = await token.balanceOf(deployerAddress);
-    const tx = await token.transfer(minter.address, amount.div(2));
-    await waitForTx(tx);
-
-    return { token, bpt, minter, gauge };
 }
 
 export async function deployCreate2Factory(
@@ -504,6 +482,15 @@ export async function setTrustedRemoteCanonical(
     tx = await canonical.auraProxyOFT.setTrustedRemote(
         sidechainLzChainId,
         ethers.utils.solidityPack(["address", "address"], [sidechain.auraOFT.address, canonical.auraProxyOFT.address]),
+    );
+    await waitForTx(tx, debug, waitForBlocks);
+
+    tx = await canonical.auraBalProxyOFT.setTrustedRemote(
+        sidechainLzChainId,
+        ethers.utils.solidityPack(
+            ["address", "address"],
+            [sidechain.auraBalOFT.address, canonical.auraBalProxyOFT.address],
+        ),
     );
     await waitForTx(tx, debug, waitForBlocks);
 

--- a/scripts/deploySidechainMocks.ts
+++ b/scripts/deploySidechainMocks.ts
@@ -1,0 +1,101 @@
+import { simpleToExactAmount } from "../test-utils/math";
+import { Signer } from "ethers";
+import {
+    MockERC20__factory,
+    MockERC20,
+    MockCurveGauge,
+    MockCurveMinter__factory,
+    MockCurveMinter,
+    MockBalancerPoolToken,
+    MockBalancerPoolToken__factory,
+    MockCurveGauge__factory,
+} from "../types/generated";
+import { deployContract } from "../tasks/utils";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { ExtSidechainConfig, SidechainNaming, SidechainMultisigConfig } from "types/sidechain-types";
+import { sidechainNaming } from "../tasks/deploy/sidechain-constants";
+import { ZERO_ADDRESS } from "../test-utils";
+
+interface DeployL2MocksResult {
+    token: MockERC20;
+    minter: MockCurveMinter;
+    gauge: MockCurveGauge;
+    bpt: MockBalancerPoolToken;
+    addresses: ExtSidechainConfig;
+    namingConfig: SidechainNaming;
+}
+/** @dev Simply fetches the addresses of the given signers to act as respective multisigs */
+async function getMockMultisigs(daoSigner: Signer): Promise<SidechainMultisigConfig> {
+    return {
+        daoMultisig: await daoSigner.getAddress(),
+    };
+}
+
+async function deploySidechainMocks(
+    hre: HardhatRuntimeEnvironment,
+    signer: Signer,
+    canonicalChainId = 111, // L1_CHAIN_ID
+    debug = false,
+    waitForBlocks = 0,
+): Promise<DeployL2MocksResult> {
+    const deployer = signer;
+    const deployerAddress = await deployer.getAddress();
+
+    const token = await deployContract<MockERC20>(
+        hre,
+        new MockERC20__factory(deployer),
+        "MockERC20",
+        ["mockToken", "mockToken", 18, deployerAddress, 10000000],
+        {},
+        debug,
+        waitForBlocks,
+    );
+    const minter = await deployContract<MockCurveMinter>(
+        hre,
+        new MockCurveMinter__factory(deployer),
+        "MockCurveMinter",
+        [token.address, simpleToExactAmount(1, 18)],
+        {},
+        debug,
+        waitForBlocks,
+    );
+    const amount = await token.balanceOf(deployerAddress);
+    const tx = await token.transfer(minter.address, amount);
+    await tx.wait();
+
+    const bpt = await deployContract<MockBalancerPoolToken>(
+        hre,
+        new MockBalancerPoolToken__factory(deployer),
+        "MockBalancerPoolToken",
+        [18, deployerAddress, 1000],
+        {},
+        debug,
+        waitForBlocks,
+    );
+
+    const gauge = await deployContract<MockCurveGauge>(
+        hre,
+        new MockCurveGauge__factory(deployer),
+        "MockCurveGauge",
+        ["MockGauge", "MOCK", bpt.address, []],
+        {},
+        debug,
+    );
+    return {
+        token,
+        bpt,
+        minter,
+        gauge,
+        addresses: {
+            canonicalChainId,
+            create2Factory: ZERO_ADDRESS,
+            token: token.address,
+            minter: minter.address,
+            gauge: gauge.address,
+            lzEndpoint: ZERO_ADDRESS,
+        },
+        namingConfig: { ...sidechainNaming },
+    };
+}
+
+export { getMockMultisigs, deploySidechainMocks, DeployL2MocksResult };

--- a/tasks/deploy/arbitrumGoerli-config.ts
+++ b/tasks/deploy/arbitrumGoerli-config.ts
@@ -1,5 +1,5 @@
 import { Signer } from "ethers";
-import { chainIds } from "../../hardhat.config";
+import { chainIds } from "../../tasks/utils";
 import {
     BoosterLite__factory,
     BoosterOwner__factory,
@@ -15,33 +15,23 @@ import {
     VirtualRewardFactory__factory,
     AuraBalVault__factory,
     SimpleStrategy__factory,
-} from "../../types";
-import {
     ExtSidechainConfig,
-    SidechainAddresses,
     SidechainConfig,
-    SidechainNaming,
     SidechainBridging,
-} from "./sidechain-types";
+    SidechainMultisigConfig,
+} from "../../types";
+import { sidechainNaming } from "./sidechain-constants";
 
-const addresses: SidechainAddresses = {
-    lzEndpoint: "0x6aB5Ae6822647046626e83ee6dB8187151E1d5ab", // https://layerzero.gitbook.io/docs/technical-reference/testnet/testnet-addresses#arbitrum-goerli-testnet
+const multisigs: SidechainMultisigConfig = {
     daoMultisig: "0x30019eB135532bDdF2Da17659101cc000C73c8e4", // Aura deployer EOA
-    minter: "0x0000000000000000000000000000000000000000", // Mock minter
-    token: "0x0000000000000000000000000000000000000000", // Mock token
-    create2Factory: "0x0000000000000000000000000000000000000000",
-};
-
-const naming: SidechainNaming = {
-    auraOftName: "Aura",
-    auraOftSymbol: "AURA",
-    auraBalOftName: "Aura BAL",
-    auraBalOftSymbol: "auraBAL",
-    tokenFactoryNamePostfix: " Aura Deposit",
 };
 
 const extConfig: ExtSidechainConfig = {
     canonicalChainId: 10121, // https://layerzero.gitbook.io/docs/technical-reference/testnet/testnet-addresses#goerli-ethereum-testnet
+    lzEndpoint: "0x6aB5Ae6822647046626e83ee6dB8187151E1d5ab", // https://layerzero.gitbook.io/docs/technical-reference/testnet/testnet-addresses#arbitrum-goerli-testnet
+    minter: "0x0000000000000000000000000000000000000000", // Mock minter
+    token: "0x0000000000000000000000000000000000000000", // Mock token
+    create2Factory: "0x0000000000000000000000000000000000000000",
 };
 
 export const bridging: SidechainBridging = {
@@ -71,8 +61,8 @@ export const getSidechain = (signer: Signer) => ({
 
 export const config: SidechainConfig = {
     chainId: chainIds.arbitrumGoerli,
-    addresses,
-    naming,
+    multisigs,
+    naming: sidechainNaming,
     extConfig,
     bridging,
     getSidechain,

--- a/tasks/deploy/gnosis-config.ts
+++ b/tasks/deploy/gnosis-config.ts
@@ -1,5 +1,5 @@
 import { Signer } from "ethers";
-import { chainIds } from "../../hardhat.config";
+import { chainIds } from "../../tasks/utils";
 import {
     BoosterLite__factory,
     BoosterOwner__factory,
@@ -15,34 +15,29 @@ import {
     AuraBalVault__factory,
     SimpleStrategy__factory,
     AuraBalOFT__factory,
+    SidechainMultisigConfig,
+    ExtSidechainConfig,
+    SidechainConfig,
+    SidechainBridging,
 } from "../../types";
 import { ZERO_ADDRESS } from "../../test-utils/constants";
-import {
-    ExtSidechainConfig,
-    SidechainAddresses,
-    SidechainConfig,
-    SidechainNaming,
-    SidechainBridging,
-} from "./sidechain-types";
+import { sidechainNaming } from "./sidechain-constants";
 
-const addresses: SidechainAddresses = {
-    lzEndpoint: "0x9740FF91F1985D8d2B71494aE1A2f723bb3Ed9E4", // https://layerzero.gitbook.io/docs/technical-reference/mainnet/supported-chain-ids#gnosis
+const multisigs: SidechainMultisigConfig = {
     daoMultisig: "0x30019eB135532bDdF2Da17659101cc000C73c8e4", // Aura deployer EOA
-    minter: ZERO_ADDRESS, // Mock minter
-    token: "0x7eF541E2a22058048904fE5744f9c7E4C57AF717", // Mock token
-    create2Factory: ZERO_ADDRESS,
-};
-
-const naming: SidechainNaming = {
-    auraOftName: "Aura",
-    auraOftSymbol: "AURA",
-    auraBalOftName: "Aura BAL",
-    auraBalOftSymbol: "auraBAL",
-    tokenFactoryNamePostfix: " Aura Deposit",
 };
 
 const extConfig: ExtSidechainConfig = {
     canonicalChainId: 145, // https://layerzero.gitbook.io/docs/technical-reference/mainnet/supported-chain-ids#gnosis
+    lzEndpoint: "0x9740FF91F1985D8d2B71494aE1A2f723bb3Ed9E4", // https://layerzero.gitbook.io/docs/technical-reference/mainnet/supported-chain-ids#gnosis
+    minter: ZERO_ADDRESS, // Mock minter
+    token: "0x7eF541E2a22058048904fE5744f9c7E4C57AF717", // Mock token
+    create2Factory: ZERO_ADDRESS,
+};
+export const bridging: SidechainBridging = {
+    l1Receiver: "0x5feA4413E3Cc5Cf3A29a49dB41ac0c24850417a0",
+    l2Sender: ZERO_ADDRESS,
+    nativeBridge: "0xf6A78083ca3e2a662D6dd1703c939c8aCE2e268d",
 };
 
 export const getSidechain = (signer: Signer) => ({
@@ -64,16 +59,10 @@ export const getSidechain = (signer: Signer) => ({
     auraBalStrategy: SimpleStrategy__factory.connect(ZERO_ADDRESS, signer),
 });
 
-export const bridging: SidechainBridging = {
-    l1Receiver: "0x5feA4413E3Cc5Cf3A29a49dB41ac0c24850417a0",
-    l2Sender: ZERO_ADDRESS,
-    nativeBridge: "0xf6A78083ca3e2a662D6dd1703c939c8aCE2e268d",
-};
-
 export const config: SidechainConfig = {
     chainId: chainIds.arbitrumGoerli,
-    addresses,
-    naming,
+    multisigs,
+    naming: sidechainNaming,
     extConfig,
     bridging,
     getSidechain,

--- a/tasks/deploy/goerli-config.ts
+++ b/tasks/deploy/goerli-config.ts
@@ -54,7 +54,7 @@ import { Signer } from "ethers";
 import { ZERO_ADDRESS } from "../../test-utils/constants";
 import { getMockDistro } from "../../scripts/deployMocks";
 import { CanonicalPhaseDeployed } from "scripts/deploySidechain";
-import { chainIds } from "../../hardhat.config";
+import { chainIds } from "../../tasks/utils";
 
 const addresses: ExtSystemConfig = {
     authorizerAdapter: "0x5d90225de345ee24d1d2b6f45de90b056f5265a1",

--- a/tasks/deploy/goerliSidechain-config.ts
+++ b/tasks/deploy/goerliSidechain-config.ts
@@ -3,7 +3,7 @@
  * that is used for testing the layerzero relayer on goerli
  */
 import { Signer } from "ethers";
-import { chainIds } from "../../hardhat.config";
+import { chainIds } from "../../tasks/utils";
 import {
     BoosterLite__factory,
     BoosterOwner__factory,
@@ -19,34 +19,24 @@ import {
     VirtualRewardFactory__factory,
     AuraBalVault__factory,
     SimpleStrategy__factory,
+    ExtSidechainConfig,
+    SidechainBridging,
+    SidechainConfig,
+    SidechainMultisigConfig,
 } from "../../types";
 import { config as goerliConfig } from "./goerli-config";
-import {
-    ExtSidechainConfig,
-    SidechainAddresses,
-    SidechainConfig,
-    SidechainNaming,
-    SidechainBridging,
-} from "./sidechain-types";
+import { sidechainNaming } from "./sidechain-constants";
 
-const addresses: SidechainAddresses = {
-    lzEndpoint: "0xbfD2135BFfbb0B5378b56643c2Df8a87552Bfa23", // https://layerzero.gitbook.io/docs/technical-reference/testnet/testnet-addresses#arbitrum-goerli-testnet
+const multisigs: SidechainMultisigConfig = {
     daoMultisig: "0x30019eB135532bDdF2Da17659101cc000C73c8e4", // Aura deployer EOA
-    minter: goerliConfig.addresses.minter, // Mock minter
-    token: goerliConfig.addresses.token, // Mock token
-    create2Factory: "0xaec901fBc8f83612011641d8aABa5B8432Dc228c",
-};
-
-const naming: SidechainNaming = {
-    auraOftName: "Aura",
-    auraOftSymbol: "AURA",
-    auraBalOftName: "Aura BAL",
-    auraBalOftSymbol: "auraBAL",
-    tokenFactoryNamePostfix: " Aura Deposit",
 };
 
 const extConfig: ExtSidechainConfig = {
     canonicalChainId: 10121, // https://layerzero.gitbook.io/docs/technical-reference/testnet/testnet-addresses#goerli-ethereum-testnet
+    lzEndpoint: "0xbfD2135BFfbb0B5378b56643c2Df8a87552Bfa23", // https://layerzero.gitbook.io/docs/technical-reference/testnet/testnet-addresses#arbitrum-goerli-testnet
+    minter: goerliConfig.addresses.minter, // Mock minter
+    token: goerliConfig.addresses.token, // Mock token
+    create2Factory: "0xaec901fBc8f83612011641d8aABa5B8432Dc228c",
 };
 
 export const bridging: SidechainBridging = {
@@ -76,8 +66,8 @@ export const getSidechain = (signer: Signer) => ({
 
 export const config: SidechainConfig = {
     chainId: chainIds.arbitrumGoerli,
-    addresses,
-    naming,
+    multisigs,
+    naming: sidechainNaming,
     extConfig,
     bridging,
     getSidechain,

--- a/tasks/deploy/mainnet-config.ts
+++ b/tasks/deploy/mainnet-config.ts
@@ -58,10 +58,14 @@ import {
     VirtualBalanceRewardPool__factory,
     AuraClaimZapV3,
     AuraClaimZapV3__factory,
+    AuraProxyOFT__factory,
+    L1Coordinator__factory,
+    AuraBalProxyOFT__factory,
 } from "../../types/generated";
 import { Signer } from "ethers";
 import { simpleToExactAmount } from "../../test-utils/math";
 import { ONE_WEEK, ZERO_ADDRESS, ZERO_KEY } from "../../test-utils/constants";
+import { CanonicalPhaseDeployed } from "scripts/deploySidechain";
 
 const addresses: ExtSystemConfig = {
     token: "0xba100000625a3754423978a60c9317c58a424e3D",
@@ -389,6 +393,12 @@ const getAuraBalVault = async (deployer: Signer): Promise<AuraBalVaultDeployed> 
 const getAuraClaimZapV3 = async (deployer: Signer): Promise<AuraClaimZapV3> =>
     AuraClaimZapV3__factory.connect("0x3eB33F9a2479Af1f98297834861fb4e053A0215f", deployer);
 
+const getSidechain = async (deployer: Signer): Promise<CanonicalPhaseDeployed> => ({
+    auraProxyOFT: AuraProxyOFT__factory.connect("0x0000000000000000000000000000000000000000", deployer),
+    auraBalProxyOFT: AuraBalProxyOFT__factory.connect("0x0000000000000000000000000000000000000000", deployer),
+    l1Coordinator: L1Coordinator__factory.connect("0x0000000000000000000000000000000000000000", deployer),
+});
+
 export const config = {
     addresses,
     naming,
@@ -405,4 +415,5 @@ export const config = {
     getFeeForwarder,
     getAuraBalVault,
     getAuraClaimZapV3,
+    getSidechain,
 };

--- a/tasks/deploy/sidechain-constants.ts
+++ b/tasks/deploy/sidechain-constants.ts
@@ -1,7 +1,8 @@
-import { chainIds } from "../../hardhat.config";
+import { chainIds } from "../../tasks/utils";
 import { config as goerliConfig } from "./goerli-config";
 import { config as arbitrumGoerliConfig } from "./arbitrumGoerli-config";
 import { config as goerliSidechainConfig } from "./goerliSidechain-config";
+import { SidechainNaming } from "../../types/sidechain-types";
 
 export const sideChains = [
     chainIds.arbitrum,
@@ -34,4 +35,12 @@ export const canonicalConfigs = {
 export const sidechainConfigs = {
     [chainIds.goerli]: goerliSidechainConfig,
     [chainIds.arbitrumGoerli]: arbitrumGoerliConfig,
+};
+
+export const sidechainNaming: SidechainNaming = {
+    auraOftName: "Aura",
+    auraOftSymbol: "AURA",
+    auraBalOftName: "Aura BAL",
+    auraBalOftSymbol: "auraBAL",
+    tokenFactoryNamePostfix: " Aura Deposit",
 };

--- a/tasks/utils/index.ts
+++ b/tasks/utils/index.ts
@@ -2,3 +2,4 @@ export * from "./signerFactory";
 export * from "./deploy-utils";
 export * from "./tokens";
 export * from "./etherscan";
+export * from "./networkAddressFactory";

--- a/tasks/utils/networkAddressFactory.ts
+++ b/tasks/utils/networkAddressFactory.ts
@@ -151,3 +151,15 @@ export const resolveToken = (
 
     return token;
 };
+
+export const chainIds = {
+    goerli: 5,
+    hardhat: 31337,
+    kovan: 42,
+    mainnet: 1,
+    rinkeby: 4,
+    ropsten: 3,
+    arbitrum: 42161,
+    arbitrumGoerli: 421613,
+    polygon: 137,
+};

--- a/test-fork/sidechain/AuraBal.spec.ts
+++ b/test-fork/sidechain/AuraBal.spec.ts
@@ -247,6 +247,15 @@ describe("AuraBalOFT", () => {
             expect(vaultBalanceAfter.sub(vaultBalanceBefore)).gte(bridgeAmount.sub(1));
             expect(vaultBalanceAfter.sub(vaultBalanceBefore)).lte(bridgeAmount);
         });
+        it("cannot call harvest when not authorized", async () => {
+            expect(await canonical.auraBalProxyOFT.authorizedHarvesters(deployer.address)).eq(false);
+            await expect(canonical.auraBalProxyOFT.harvest([L2_CHAIN_ID], [100], 100)).to.be.revertedWith("!harvester");
+        });
+        it("set authorized harvester", async () => {
+            expect(await canonical.auraBalProxyOFT.authorizedHarvesters(deployer.address)).eq(false);
+            await canonical.auraBalProxyOFT.updateAuthorizedHarvesters(deployer.address, true);
+            expect(await canonical.auraBalProxyOFT.authorizedHarvesters(deployer.address)).eq(true);
+        });
         it("can harvest auraBAL from vault", async () => {
             const harvestAmount = simpleToExactAmount(100);
             await getAuraBal(phase2, mainnetConfig.addresses, vaultDeployment.strategy.address, harvestAmount);

--- a/test-fork/sidechain/GnosisBridge.spec.ts
+++ b/test-fork/sidechain/GnosisBridge.spec.ts
@@ -4,7 +4,7 @@ import { BigNumberish } from "ethers";
 import { deployGnosisBridgeSender } from "../../scripts/deployBridgeDelegates";
 import { config as mainnetConfig } from "../../tasks/deploy/mainnet-config";
 import { config as gnosisConfig } from "../../tasks/deploy/gnosis-config";
-import { impersonateAccount, simpleToExactAmount, ZERO_ADDRESS } from "../../test-utils";
+import { impersonateAccount, simpleToExactAmount } from "../../test-utils";
 import { Account, ERC20, MockERC20__factory, GnosisBridgeSender } from "../../types";
 
 describe("GnosisBridge", () => {
@@ -56,13 +56,13 @@ describe("GnosisBridge", () => {
         dao = await impersonateAccount(mainnetConfig.multisigs.daoMultisig);
 
         // Deploy mocks
-        crv = MockERC20__factory.connect(gnosisConfig.addresses.token, deployer.signer);
+        crv = MockERC20__factory.connect(gnosisConfig.extConfig.token, deployer.signer);
 
         gnosisBridgeSender = await deployGnosisBridgeSender(
             hre,
             deployer.signer,
             gnosisConfig.bridging.nativeBridge,
-            gnosisConfig.addresses.token,
+            gnosisConfig.extConfig.token,
         );
     });
 
@@ -74,7 +74,7 @@ describe("GnosisBridge", () => {
             expect(await gnosisBridgeSender.l1Receiver()).eq(deployer.address);
             expect(await gnosisBridgeSender.l2Coordinator()).eq(gnosisConfig.bridging.l1Receiver);
             expect(await gnosisBridgeSender.bridge()).eq(gnosisConfig.bridging.nativeBridge);
-            expect(await gnosisBridgeSender.crv()).eq(gnosisConfig.addresses.token);
+            expect(await gnosisBridgeSender.crv()).eq(gnosisConfig.extConfig.token);
         });
     });
 

--- a/test/convex-platform/BaseRewardPool4626.spec.ts
+++ b/test/convex-platform/BaseRewardPool4626.spec.ts
@@ -97,6 +97,13 @@ describe("BaseRewardPool4626", () => {
             expect(await crvRewards.name()).eq(`${await auraBPT.name()} Vault`);
             expect(await crvRewards.symbol()).eq(`${await auraBPT.symbol()}-vault`);
         });
+        it("does not support transfer or transferFrom", async () => {
+            const crvRewards = BaseRewardPool4626__factory.connect(pool.crvRewards, alice);
+            await expect(crvRewards.transfer(deployerAddress, 1)).to.be.revertedWith("ERC4626: Not supported");
+            await expect(crvRewards.transferFrom(deployerAddress, deployerAddress, 1)).to.be.revertedWith(
+                "ERC4626: Not supported",
+            );
+        });
         it("does support approval and allowances", async () => {
             const crvRewards = BaseRewardPool4626__factory.connect(pool.crvRewards, alice);
             const tx = await crvRewards.approve(deployerAddress, 1);
@@ -260,39 +267,6 @@ describe("BaseRewardPool4626", () => {
             expect(rwdBalanceAfter).eq(0);
             expect(await crvRewards.maxWithdraw(aliceAddress)).eq(rwdBalanceAfter);
             expect(await crvRewards.maxRedeem(aliceAddress)).eq(rwdBalanceAfter);
-        });
-        it("allows transferFrom between accounts", async () => {
-            // TODO - add checks for VirtualRewardPool
-            const alternateReceiverAddress = await alternateReceiver.getAddress();
-            const crvRewards = BaseRewardPool4626__factory.connect(pool.crvRewards, alternateReceiver);
-            const aliceBalanceBefore = await crvRewards.balanceOf(aliceAddress);
-            const alternateReceiverBalanceBefore = await crvRewards.balanceOf(alternateReceiverAddress);
-            const amount = alternateReceiverBalanceBefore.div(4);
-
-            // Alternate approves deployer to transfer tokens
-            await crvRewards.approve(deployerAddress, amount);
-            await crvRewards.connect(deployer).transferFrom(alternateReceiverAddress, aliceAddress, amount);
-            const aliceBalanceAfter = await crvRewards.balanceOf(aliceAddress);
-            const alternateReceiverBalanceAfter = await crvRewards.balanceOf(alternateReceiverAddress);
-
-            expect(aliceBalanceAfter.sub(aliceBalanceBefore)).eq(amount);
-            expect(alternateReceiverBalanceBefore.sub(alternateReceiverBalanceAfter)).eq(amount);
-        });
-        it("allows transfer between accounts", async () => {
-            const alternateReceiverAddress = await alternateReceiver.getAddress();
-            const crvRewards = BaseRewardPool4626__factory.connect(pool.crvRewards, alice);
-            const aliceBalanceBefore = await crvRewards.balanceOf(aliceAddress);
-            const alternateReceiverBalanceBefore = await crvRewards.balanceOf(alternateReceiverAddress);
-            const amount = aliceBalanceBefore;
-
-            // Alice transfer to alternate receiver
-            await crvRewards.transfer(alternateReceiverAddress, amount);
-
-            const aliceBalanceAfter = await crvRewards.balanceOf(aliceAddress);
-            const alternateReceiverBalanceAfter = await crvRewards.balanceOf(alternateReceiverAddress);
-
-            expect(aliceBalanceBefore.sub(aliceBalanceAfter)).eq(amount);
-            expect(alternateReceiverBalanceAfter.sub(alternateReceiverBalanceBefore)).eq(amount);
         });
         it("allows direct withdraws for alternate receiver", async () => {
             const amount = ethers.utils.parseEther("10");

--- a/test/sidechain/sidechainTestSetup.ts
+++ b/test/sidechain/sidechainTestSetup.ts
@@ -1,0 +1,188 @@
+import { Signer } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types/runtime";
+import {
+    MultisigConfig,
+    Phase2Deployed,
+    Phase6Deployed,
+    deployPhase1,
+    deployPhase2,
+    deployPhase3,
+    deployPhase4,
+    deployPhase6,
+} from "../../scripts/deploySystem";
+import { DeployMocksResult, deployMocks, getMockDistro, getMockMultisigs } from "../../scripts/deployMocks";
+import { impersonateAccount } from "../../test-utils/fork";
+import {
+    deployCanonicalPhase,
+    deploySidechainSystem,
+    setTrustedRemoteCanonical,
+    CanonicalPhaseDeployed,
+    SidechainDeployed,
+    setTrustedRemoteSidechain,
+} from "../../scripts/deploySidechain";
+import { Account, Create2Factory__factory, LZEndpointMock__factory, SidechainMultisigConfig } from "../../types";
+import {
+    DeployL2MocksResult,
+    deploySidechainMocks,
+    getMockMultisigs as getL2MockMultisigs,
+} from "../../scripts/deploySidechainMocks";
+import { deploySimpleBridgeDelegates, SimplyBridgeDelegateDeployed } from "../../scripts/deployBridgeDelegates";
+import { deployVault } from "../../scripts/deployVault";
+
+export interface L1TestSetup {
+    mocks: DeployMocksResult;
+    multisigs: MultisigConfig;
+    phase2: Phase2Deployed;
+    phase6: Phase6Deployed;
+    canonical: CanonicalPhaseDeployed;
+}
+export interface L2TestSetup {
+    mocks: DeployL2MocksResult;
+    multisigs: SidechainMultisigConfig;
+    sidechain: SidechainDeployed;
+}
+export interface SideChainTestSetup {
+    deployer: Account;
+    l1: L1TestSetup;
+    l2: L2TestSetup;
+    bridgeDelegates: SimplyBridgeDelegateDeployed;
+}
+
+/**
+ * Full deployment of the system in order to test sidechain stuff.
+ * - L1: phase 1 to 6, canonical phase, mocks, multisigs
+ * - L2: phase 1 to 2, mocks, multisigs
+ *
+ * - Configures layer zero to enable communication between L1 <=> L2
+ *
+ * @param {HardhatRuntimeEnvironment} hre - The Hardhat runtime environment
+ * @param {Signer[]} accounts - Array of accounts to use.
+ * @param {number} canonicalChainId - The ID of the canonical chain, or L1
+ * @param {number} sidechainLzChainId - The ID of the canonical chain, or L2
+ * @returns {SideChainTestSetup}
+ */
+export const sidechainTestSetup = async (
+    hre: HardhatRuntimeEnvironment,
+    accounts: Signer[],
+    canonicalChainId = 111,
+    sidechainLzChainId = 222,
+    debug = false,
+    waitForBlocks = 0,
+): Promise<SideChainTestSetup> => {
+    const deployer = await impersonateAccount(await accounts[0].getAddress());
+    const l1Mocks = await deployMocks(hre, deployer.signer);
+    const l2mocks = await deploySidechainMocks(hre, deployer.signer, canonicalChainId, debug, waitForBlocks);
+    const l1Multisigs = await getMockMultisigs(accounts[1], accounts[2], accounts[3]);
+    const l2Multisigs = await getL2MockMultisigs(accounts[3]);
+    const dao = await impersonateAccount(l2Multisigs.daoMultisig);
+
+    const distro = getMockDistro();
+    const phase1 = await deployPhase1(hre, deployer.signer, l1Mocks.addresses);
+    const phase2 = await deployPhase2(
+        hre,
+        deployer.signer,
+        phase1,
+        distro,
+        l1Multisigs,
+        l1Mocks.namingConfig,
+        l1Mocks.addresses,
+    );
+    const phase3 = await deployPhase3(hre, deployer.signer, phase2, l1Multisigs, l1Mocks.addresses);
+    await phase3.poolManager.connect(dao.signer).setProtectPool(false);
+    await deployPhase4(hre, deployer.signer, phase3, l1Mocks.addresses);
+    const phase6 = await deployPhase6(
+        hre,
+        deployer.signer,
+        phase2,
+        l1Multisigs,
+        l1Mocks.namingConfig,
+        l1Mocks.addresses,
+    );
+    const vaultDeployment = await deployVault(
+        {
+            addresses: l1Mocks.addresses,
+            multisigs: l1Multisigs,
+            getPhase2: async (__: Signer) => phase2,
+            getPhase6: async (__: Signer) => phase6,
+        },
+        hre,
+        deployer.signer,
+    );
+
+    // deploy canonicalPhase
+    const canonical = await deployCanonicalPhase(
+        hre,
+        deployer.signer,
+        l1Multisigs,
+        l1Mocks.addresses,
+        phase2,
+        phase6,
+        vaultDeployment,
+    );
+    // deploy sidechain
+    const create2Factory = await new Create2Factory__factory(deployer.signer).deploy();
+    await create2Factory.updateDeployer(deployer.address, true);
+
+    const l2LzEndpoint = await new LZEndpointMock__factory(deployer.signer).deploy(sidechainLzChainId);
+    l2mocks.addresses.lzEndpoint = l2LzEndpoint.address;
+
+    const sidechain = await deploySidechainSystem(hre, deployer.signer, l2mocks.namingConfig, l2Multisigs, {
+        ...l2mocks.addresses,
+        create2Factory: create2Factory.address,
+    });
+
+    await sidechain.poolManager.connect(dao.signer).setProtectPool(false);
+    // Mock L1 Endpoints  configuration
+    await l1Mocks.lzEndpoint.setDestLzEndpoint(sidechain.l2Coordinator.address, l2LzEndpoint.address);
+    await l1Mocks.lzEndpoint.setDestLzEndpoint(sidechain.auraOFT.address, l2LzEndpoint.address);
+    await l1Mocks.lzEndpoint.setDestLzEndpoint(sidechain.auraBalOFT.address, l2LzEndpoint.address);
+
+    // Mock L12Endpoints  configuration
+    await l2LzEndpoint.setDestLzEndpoint(canonical.l1Coordinator.address, l1Mocks.lzEndpoint.address);
+    await l2LzEndpoint.setDestLzEndpoint(canonical.auraProxyOFT.address, l1Mocks.lzEndpoint.address);
+    await l2LzEndpoint.setDestLzEndpoint(canonical.auraBalProxyOFT.address, l1Mocks.lzEndpoint.address);
+
+    // Add Mock Gauge
+    await sidechain.poolManager["addPool(address)"](l2mocks.gauge.address);
+
+    // Emulate DAO Settings - L1 Stuff
+    await phase6.booster.connect(dao.signer).setBridgeDelegate(canonical.l1Coordinator.address);
+    canonical.l1Coordinator = canonical.l1Coordinator.connect(dao.signer);
+    canonical.auraProxyOFT = canonical.auraProxyOFT.connect(dao.signer);
+    canonical.auraBalProxyOFT = canonical.auraBalProxyOFT.connect(dao.signer);
+    await setTrustedRemoteCanonical(canonical, sidechain, sidechainLzChainId);
+
+    // Emulate DAO Settings - L2 Stuff
+    sidechain.l2Coordinator = sidechain.l2Coordinator.connect(dao.signer);
+    sidechain.auraOFT = sidechain.auraOFT.connect(dao.signer);
+    sidechain.auraBalOFT = sidechain.auraBalOFT.connect(dao.signer);
+    await setTrustedRemoteSidechain(canonical, sidechain, l2mocks.addresses.canonicalChainId);
+
+    const sbd = await deploySimpleBridgeDelegates(
+        hre,
+        l1Mocks.addresses,
+        canonical,
+        sidechainLzChainId,
+        deployer.signer,
+    );
+    await canonical.l1Coordinator
+        .connect(dao.signer)
+        .setBridgeDelegate(sidechainLzChainId, sbd.bridgeDelegateReceiver.address);
+    await canonical.l1Coordinator
+        .connect(dao.signer)
+        .setL2Coordinator(sidechainLzChainId, sidechain.l2Coordinator.address);
+
+    await sidechain.l2Coordinator.connect(dao.signer).setBridgeDelegate(sbd.bridgeDelegateSender.address);
+
+    // Revert connected contracts with deployer signer
+    canonical.l1Coordinator = canonical.l1Coordinator.connect(deployer.signer);
+    sidechain.l2Coordinator = sidechain.l2Coordinator.connect(deployer.signer);
+    sidechain.auraOFT = sidechain.auraOFT.connect(deployer.signer);
+    sidechain.auraBalOFT = sidechain.auraBalOFT.connect(deployer.signer);
+    return {
+        deployer,
+        l1: { mocks: l1Mocks, multisigs: l1Multisigs, phase2, phase6, canonical },
+        l2: { mocks: l2mocks, multisigs: l2Multisigs, sidechain },
+        bridgeDelegates: { ...sbd },
+    };
+};

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./common"
+export * from "./sidechain-types"
 export * from "./generated"

--- a/types/sidechain-types.ts
+++ b/types/sidechain-types.ts
@@ -1,14 +1,6 @@
 import { Signer } from "ethers";
 import { SidechainDeployed } from "scripts/deploySidechain";
 
-export interface SidechainAddresses {
-    lzEndpoint: string;
-    token: string;
-    daoMultisig: string;
-    minter: string;
-    create2Factory: string;
-}
-
 export interface SidechainNaming {
     auraOftName: string;
     auraOftSymbol: string;
@@ -18,7 +10,16 @@ export interface SidechainNaming {
 }
 
 export interface ExtSidechainConfig {
+    token: string;
+    minter: string;
     canonicalChainId: number;
+    lzEndpoint: string;
+    create2Factory: string;
+    gauge?: string;
+}
+
+export interface SidechainMultisigConfig {
+    daoMultisig: string;
 }
 
 export interface SidechainBridging {
@@ -28,8 +29,8 @@ export interface SidechainBridging {
 }
 
 export interface SidechainConfig {
-    chainId: number;
-    addresses: SidechainAddresses;
+    chainId: number,
+    multisigs: SidechainMultisigConfig;
     naming: SidechainNaming;
     extConfig: ExtSidechainConfig;
     bridging: SidechainBridging;


### PR DESCRIPTION
- refactor sidechain deployment scripts to match previous deployment scripts pattern
- move chainids configuration out of hardhat.config.ts, as it causes errors on hardhat tasks  to load hh configuration while initialising the task
- add LZEndpointMock to deployMocks script.
- splits mock deployments from scripts/deploySidechain.ts
- changes references on sidechain from BoosterOwner => BoosterOwnerLite 