### PR TITLE
[Feat] AuraVestedEscrowV2

### DIFF
--- a/contracts/rewards/AuraVestedEscrowV2.sol
+++ b/contracts/rewards/AuraVestedEscrowV2.sol
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.11;
+
+import { IAuraLocker } from "../interfaces/IAuraLocker.sol";
+import { IERC20 } from "@openzeppelin/contracts-0.8/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts-0.8/token/ERC20/utils/SafeERC20.sol";
+import { ReentrancyGuard } from "@openzeppelin/contracts-0.8/security/ReentrancyGuard.sol";
+import { AuraMath } from "../utils/AuraMath.sol";
+
+/**
+ * @title   AuraVestedEscrow
+ * @author  adapted from ConvexFinance (convex-platform/contracts/contracts/VestedEscrow)
+ * @notice  Vests tokens over a given timeframe to an array of recipients. Allows locking of
+ *          these tokens directly to staking contract.
+ * @dev     Adaptations:
+ *           - One time initialisation
+ *           - Consolidation of fundAdmin/admin
+ *           - Lock in AuraLocker by default
+ *           - Start and end time
+ */
+contract AuraVestedEscrowV2 is ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    IERC20 public immutable rewardToken;
+
+    address public admin;
+    address public immutable funder;
+    IAuraLocker public auraLocker;
+
+    uint256 public immutable startTime;
+    uint256 public immutable endTime;
+    uint256 public immutable totalTime;
+
+    bool public initialised = false;
+
+    mapping(address => uint256) public totalLocked;
+    mapping(address => uint256) public totalClaimed;
+
+    event Funded(address indexed recipient, uint256 reward);
+    event Cancelled(address indexed recipient);
+    event Claim(address indexed user, uint256 amount, bool locked);
+
+    /**
+     * @param rewardToken_    Reward token (AURA)
+     * @param admin_          Admin to cancel rewards
+     * @param auraLocker_     Contract where rewardToken can be staked
+     * @param starttime_      Timestamp when claim starts
+     * @param endtime_        When vesting ends
+     */
+    constructor(
+        address rewardToken_,
+        address admin_,
+        address funder_,
+        address auraLocker_,
+        uint256 starttime_,
+        uint256 endtime_
+    ) {
+        require(starttime_ >= block.timestamp, "start must be future");
+        require(endtime_ > starttime_, "end must be greater");
+
+        rewardToken = IERC20(rewardToken_);
+        admin = admin_;
+        funder = funder_;
+        auraLocker = IAuraLocker(auraLocker_);
+
+        startTime = starttime_;
+        endTime = endtime_;
+        totalTime = endTime - startTime;
+        require(totalTime >= 16 weeks, "!short");
+    }
+
+    /***************************************
+                    SETUP
+    ****************************************/
+
+    /**
+     * @notice Change contract admin
+     * @param _admin New admin address
+     */
+    function setAdmin(address _admin) external {
+        require(msg.sender == admin, "!auth");
+        admin = _admin;
+    }
+
+    /**
+     * @notice Change locker contract address
+     * @param _auraLocker Aura Locker address
+     */
+    function setLocker(address _auraLocker) external {
+        require(msg.sender == admin, "!auth");
+        auraLocker = IAuraLocker(_auraLocker);
+    }
+
+    /**
+     * @notice Fund recipients with rewardTokens
+     * @param _recipient  Array of recipients to vest rewardTokens for
+     * @param _amount     Arrary of amount of rewardTokens to vest
+     */
+    function fund(address[] calldata _recipient, uint256[] calldata _amount) external nonReentrant {
+        require(_recipient.length == _amount.length, "!arr");
+        require(!initialised, "initialised already");
+        require(msg.sender == funder, "!funder");
+        require(block.timestamp < startTime, "already started");
+
+        uint256 totalAmount = 0;
+        for (uint256 i = 0; i < _recipient.length; i++) {
+            uint256 amount = _amount[i];
+
+            totalLocked[_recipient[i]] += amount;
+            totalAmount += amount;
+
+            emit Funded(_recipient[i], amount);
+        }
+        rewardToken.safeTransferFrom(msg.sender, address(this), totalAmount);
+        initialised = true;
+    }
+
+    /**
+     * @notice Cancel recipients vesting rewardTokens
+     * @param _recipient Recipient address
+     */
+    function cancel(address _recipient) external nonReentrant {
+        require(msg.sender == admin, "!auth");
+        require(totalLocked[_recipient] > 0, "!funding");
+
+        _claim(_recipient, false);
+
+        uint256 delta = remaining(_recipient);
+        rewardToken.safeTransfer(admin, delta);
+
+        totalLocked[_recipient] = 0;
+
+        emit Cancelled(_recipient);
+    }
+
+    /***************************************
+                    VIEWS
+    ****************************************/
+
+    /**
+     * @notice Available amount to claim
+     * @param _recipient Recipient to lookup
+     */
+    function available(address _recipient) public view returns (uint256) {
+        uint256 vested = _totalVestedOf(_recipient, block.timestamp);
+        return vested - totalClaimed[_recipient];
+    }
+
+    /**
+     * @notice Total remaining vested amount
+     * @param _recipient Recipient to lookup
+     */
+    function remaining(address _recipient) public view returns (uint256) {
+        uint256 vested = _totalVestedOf(_recipient, block.timestamp);
+        return totalLocked[_recipient] - vested;
+    }
+
+    /**
+     * @notice Get total amount vested for this timestamp
+     * @param _recipient  Recipient to lookup
+     * @param _time       Timestamp to check vesting amount for
+     */
+    function _totalVestedOf(address _recipient, uint256 _time) internal view returns (uint256 total) {
+        if (_time < startTime) {
+            return 0;
+        }
+        uint256 locked = totalLocked[_recipient];
+        uint256 elapsed = _time - startTime;
+        total = AuraMath.min((locked * elapsed) / totalTime, locked);
+    }
+
+    /***************************************
+                    CLAIM
+    ****************************************/
+
+    function claim(bool _lock) external nonReentrant {
+        _claim(msg.sender, _lock);
+    }
+
+    /**
+     * @dev Claim reward token (Aura) and lock it.
+     * @param _recipient  Address to receive rewards.
+     * @param _lock       Lock rewards immediately.
+     */
+    function _claim(address _recipient, bool _lock) internal {
+        uint256 claimable = available(_recipient);
+
+        totalClaimed[_recipient] += claimable;
+
+        if (_lock) {
+            require(address(auraLocker) != address(0), "!auraLocker");
+            rewardToken.safeApprove(address(auraLocker), claimable);
+            auraLocker.lock(_recipient, claimable);
+        } else {
+            rewardToken.safeTransfer(_recipient, claimable);
+        }
+
+        emit Claim(_recipient, claimable, _lock);
+    }
+}

--- a/deployments/1.json
+++ b/deployments/1.json
@@ -64,5 +64,6 @@
     "WardenQuestScheduler": "0x3FCB0Cc19C41E9D2DB3b9764032CD457bAA2fb47",
     "gaugeVoteRewards": "0x26094f9A6a498c1FCCd8Ff65829F55FB8BD72A4E",
     "stashRewardDistro": "0xD3a5b62A89e3F5cC61e29f5b7549C83564F998F1",
-    "Forwarder Handler": "0x7663FD322021D5b1f36dBf0c97D34cfa039fCCA1"
+    "Forwarder Handler": "0x7663FD322021D5b1f36dBf0c97D34cfa039fCCA1",
+    "vestedEscrow-6": "0xa6bBF685b7EA73878b4FB867A96f1Ca3ED5eB358"
 }


### PR DESCRIPTION
## Summary

A copy of AuraVestedEscrow which accepts `funder` as an argument in the constructor rather than using `msg.sender` while avoiding having to update all our other code that this change would break if we just added it to `AuraVestedEscrow.sol`. 

## Code Diff

```diff
@@ -18,7 +18,7 @@ import { AuraMath } from "../utils/AuraMath.sol";
  *           - Lock in AuraLocker by default
  *           - Start and end time
  */
-contract AuraVestedEscrow is ReentrancyGuard {
+contract AuraVestedEscrowV2 is ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     IERC20 public immutable rewardToken;
@@ -50,6 +50,7 @@ contract AuraVestedEscrow is ReentrancyGuard {
     constructor(
         address rewardToken_,
         address admin_,
+        address funder_,
         address auraLocker_,
         uint256 starttime_,
         uint256 endtime_
@@ -59,7 +60,7 @@ contract AuraVestedEscrow is ReentrancyGuard {
 
         rewardToken = IERC20(rewardToken_);
         admin = admin_;
-        funder = msg.sender;
+        funder = funder_;
         auraLocker = IAuraLocker(auraLocker_);
 
         startTime = starttime_;
```